### PR TITLE
Rivettp/LCC11-24 #comment - revised the core language and country ontologies...

### DIFF
--- a/Countries/CountryRepresentation.rdf
+++ b/Countries/CountryRepresentation.rdf
@@ -19,7 +19,7 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:dct="http://purl.org/dc/terms/"
      xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+     xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
      xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
      xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 
@@ -30,11 +30,10 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
     <!-- Curation and Rights Metadata for the LCC Country and Subdivision Representation Ontology -->
 
-        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 Object Management Group, Inc.
-Copyright (c) 2015-2017 Adaptive Inc.
-Copyright (c) 2015-2017 Thematix Partners LLC
-Copyright (c) 2015-2017 Unisys
-</sm:copyright>
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2019 Object Management Group, Inc.</sm:copyright>
+        <sm:copyright>Copyright (c) 2015-2019 Adaptive Inc.</sm:copyright>
+        <sm:copyright>Copyright (c) 2015-2019 Thematix Partners LLC</sm:copyright>
+        <sm:copyright>Copyright (c) 2015-2017 Unisys</sm:copyright>
         <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
 
 
@@ -42,7 +41,7 @@ Copyright (c) 2015-2017 Unisys
 
         <sm:filename rdf:datatype="&xsd;string">CountryRepresentation.rdf</sm:filename>
         <sm:fileAbbreviation rdf:datatype="&xsd;string">lcc-cr</sm:fileAbbreviation>
-        <owl:versionIRI rdf:resource="http://www.omg.org/spec/LCC/20170801/Countries/CountryRepresentation/"/>
+        <owl:versionIRI rdf:resource="https://www.omg.org/spec/LCC/20190201/Countries/CountryRepresentation/"/>
         <sm:fileAbstract rdf:datatype="&xsd;string">The purpose of the Country Representation ontology, based on ISO 3166 and other representations of geographic regions and countries, such as the ISO Online Browsing Platform, UN M49 Region codes, SWIFT registry, UN FAO and CIA World Factbook, FIPA and International Olympics codes for countries, and GeoNames, is to provide a systematic description of the vocabulary used for country and geopolitical entity representation (based strictly on requirements for business applications, not broader geographic or political uses). A few additional properties to support geophysical coordinates, identified in the UN FAO and CIA World Factbook as well as from the well-known GeoNames ontology, have been added, but extensions to support other coding systems, such as the FAOSTAT code, have not been included.
 
 ISO 3166 provides widely, though not universally, applicable coded representations of names of countries, dependencies, and other areas of particular geopolitical interest and their subdivisions.
@@ -63,6 +62,7 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <sm:relatedSpecification rdf:datatype="&xsd;string">International Olympic Committee list of national committees and their representation, see https://www.olympic.org/national-olympic-committees</sm:relatedSpecification>
 
         <skos:changeNote rdf:datatype="&xsd;string">The http://www.omg.org/spec/LCC/20151101/Countries/CountryRepresentation.rdf version of this ontology has been revised to reflect the issues addressed by the LCC 1.0 FTF report. This includes generalizing the ontology to accommodate country and region coding systems in addition to the ISO 3166 codes, providing some flexibility to use this ontology as the schema to support integration and use of other systems.  Such coding systems might include governmental and corporate distinctions from the codes published by the U.N. and standardized by ISO, or reflect domain-specific codes such as the International Olympic Committee, International Federation of Association Football (FIFA), or other international or national sporting organizations. The structure of the ontologies representing the codes themselves has been revised to support an ontology per country for the subdivision codes, so that users can leverage only those they need rather than having to load close to five thousand individuals for applications requiring a small subset of that number. Generation of the country and subdivision ontologies is entirely automated to facilitate change management going forward.</skos:changeNote>
+		<skos:changeNote rdf:datatype="&xsd;string">The http://www.omg.org/spec/LCC/20171801/Countries/CountryRepresentation.rdf version of this ontology was revised loosen the range constraints on the hasName properties to enable use of language tags, as stated in the LCC 1.1 RTF report.</skos:changeNote>
         <sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/</sm:dependsOn>
 
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
@@ -167,7 +167,7 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has English full name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the full name, if different from the short form of the country name, in lower case</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasEnglishName"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -175,7 +175,7 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has English short name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the short form of the country name, in English</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasEnglishName"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -183,7 +183,7 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has English short name in capitals</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the short form of the country name, in English (capitals)</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasEnglishName"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -191,7 +191,7 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has French full name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the full name, if different from the short form of the country name, in lower case</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasFrenchName"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -199,7 +199,7 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has French short name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the short form of the country name, in French</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasFrenchName"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -207,7 +207,7 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has French short name in capitals</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the short form of the country name, in French (capitals)</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasFrenchName"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -236,7 +236,7 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has local short name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the local, regional, cultural, or indigenous short form of the country name</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -356,42 +356,42 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasEnglishShortName"/>
-                <owl:onDataRange rdf:resource="&xsd;string"/>
+                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
                 <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasFrenchShortNameInCapitals"/>
-                <owl:onDataRange rdf:resource="&xsd;string"/>
+                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
                 <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasEnglishShortNameInCapitals"/>
-                <owl:onDataRange rdf:resource="&xsd;string"/>
+                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
                 <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasFrenchShortName"/>
-                <owl:onDataRange rdf:resource="&xsd;string"/>
+                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
                 <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasEnglishFullName"/>
-                <owl:onDataRange rdf:resource="&xsd;string"/>
+                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
                 <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasFrenchFullName"/>
-                <owl:onDataRange rdf:resource="&xsd;string"/>
+                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
                 <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>

--- a/Countries/CountryRepresentation.rdf
+++ b/Countries/CountryRepresentation.rdf
@@ -167,7 +167,6 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has English full name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the full name, if different from the short form of the country name, in lower case</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasEnglishName"/>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -175,7 +174,6 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has English short name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the short form of the country name, in English</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasEnglishName"/>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -183,7 +181,6 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has English short name in capitals</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the short form of the country name, in English (capitals)</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasEnglishName"/>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -191,7 +188,6 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has French full name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the full name, if different from the short form of the country name, in lower case</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasFrenchName"/>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -199,7 +195,6 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has French short name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the short form of the country name, in French</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasFrenchName"/>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -207,7 +202,6 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has French short name in capitals</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the short form of the country name, in French (capitals)</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasFrenchName"/>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -236,7 +230,6 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:label>has local short name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the local, regional, cultural, or indigenous short form of the country name</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-cr;"/>
     </owl:DatatypeProperty>
     
@@ -356,43 +349,37 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasEnglishShortName"/>
-                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasFrenchShortNameInCapitals"/>
-                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasEnglishShortNameInCapitals"/>
-                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasFrenchShortName"/>
-                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasEnglishFullName"/>
-                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
-                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;hasFrenchFullName"/>
-                <owl:onDataRange rdf:resource="&rdfs;Literal"/>
-                <owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -404,8 +391,7 @@ This ontology provides a reference model to support the first two parts of ISO 3
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-cr;isIndependent"/>
-                <owl:onDataRange rdf:resource="&xsd;boolean"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <skos:definition rdf:datatype="&xsd;string">a geopolitical entity representing a country or dependent territory</skos:definition>

--- a/Languages/LanguageRepresentation.rdf
+++ b/Languages/LanguageRepresentation.rdf
@@ -28,11 +28,10 @@
 
     <!-- Curation and Rights Metadata for the LCC Language Representation Ontology -->
 
-        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 Object Management Group, Inc.
-Copyright (c) 2015-2017 Adaptive Inc.
-Copyright (c) 2015-2017 Thematix Partners LLC
-Copyright (c) 2015-2017 Unisys
-</sm:copyright>
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2019 Object Management Group, Inc.</sm:copyright>
+        <sm:copyright>Copyright (c) 2015-2019 Adaptive Inc.</sm:copyright>
+        <sm:copyright>Copyright (c) 2015-2019 Thematix Partners LLC</sm:copyright>
+        <sm:copyright>Copyright (c) 2015-2017 Unisys</sm:copyright>
         <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
 
 
@@ -40,7 +39,7 @@ Copyright (c) 2015-2017 Unisys
 
         <sm:filename rdf:datatype="&xsd;string">LanguageRepresentation.rdf</sm:filename>
         <sm:fileAbbreviation rdf:datatype="&xsd;string">lcc-lr</sm:fileAbbreviation>
-        <owl:versionIRI rdf:resource="http://www.omg.org/spec/LCC/20170801/Languages/LanguageRepresentation/"/>
+        <owl:versionIRI rdf:resource="https://www.omg.org/spec/LCC/20190201/Languages/LanguageRepresentation/"/>
         <sm:fileAbstract rdf:datatype="&xsd;string">This ontology, based on ISO 639 as well as the language element of the Language Tag specified in BCP 47 (RFC 4646, RFC 4647), provides a systemic description of the vocabulary used for language representation, including natural and artificial languages. 
 
 ISO 639 provides two language codes, one as a two-letter code (ISO 639-1) and another as a three-letter code (ISO 639-2, ISO 639-3, ISO 639-5) for the representation of names of languages.  ISO 639-1 was devised primarily for use in terminology, lexicography, and linguistics.  ISO 639-2 represents all of the languages contained in ISO 639-1, additional languages and language groups, as they may be coded for special purposes when more specificity in coding is needed.  The languages listed in ISO 639-1 are a subset of the languages listed in ISO 639-2; every language code element in the two-letter code has a corresponding language code element in the three-letter code, but not necessarily vice versa.  ISO 639-4 provides the basis for describing languages, as defined in this ontology, and additional codes are provided in 639-5 and other parts of the standard, again with more details about macrolanguages, other lesser known independent languages, and special language groups.
@@ -84,7 +83,7 @@ This ontology (Language Representation) defines the model for the standard, base
 6.  The LCC 1.0 version of this ontology, published in advance of the 2017 New Orleans OMG Technical Meeting, was current as of 31 July 2017 with respect to the ISO 639-1 and 639-2 codes included herein.</skos:historyNote>
 
         <skos:changeNote rdf:datatype="&xsd;string">The http://www.omg.org/spec/LCC/20151101/Languages/LanguageRepresentation.rdf version of this ontology was revised to reflect the issues addressed by the LCC 1.0 FTF report.</skos:changeNote>
-
+		<skos:changeNote rdf:datatype="&xsd;string">The http://www.omg.org/spec/LCC/20171801/Languages/LanguageRepresentation.rdf version of this ontology was revised loosen the range constraints on the hasName properties to enable use of language tags, as stated in the LCC 1.1 RTF report.</skos:changeNote>
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 
@@ -171,7 +170,7 @@ This ontology (Language Representation) defines the model for the standard, base
     <owl:DatatypeProperty rdf:about="&lcc-lr;hasName">
         <rdfs:label>has name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">associates a name, reference name, or appellation with an individual concept</skos:definition>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <dct:source rdf:datatype="&xsd;string">Section 3.4, ISO 639-3</dct:source>
         <rdfs:isDefinedBy rdf:resource="&lcc-lr;"/>
 	</owl:DatatypeProperty>
@@ -180,7 +179,7 @@ This ontology (Language Representation) defines the model for the standard, base
         <rdfs:label>has English name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">associates a name in English with an individual concept</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <dct:source rdf:datatype="&xsd;string">Section 3.4, ISO 639-3</dct:source>
         <rdfs:isDefinedBy rdf:resource="&lcc-lr;"/>
 	</owl:DatatypeProperty>
@@ -189,7 +188,7 @@ This ontology (Language Representation) defines the model for the standard, base
         <rdfs:label>has French name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">associates a name in French with an individual concept</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <dct:source rdf:datatype="&xsd;string">Section 3.4, ISO 639-3</dct:source>
         <rdfs:isDefinedBy rdf:resource="&lcc-lr;"/>
 	</owl:DatatypeProperty>
@@ -198,7 +197,7 @@ This ontology (Language Representation) defines the model for the standard, base
         <rdfs:label>has German name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">associates a name in German with an individual concept</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-lr;"/>
 	</owl:DatatypeProperty>
     
@@ -206,7 +205,7 @@ This ontology (Language Representation) defines the model for the standard, base
         <rdfs:label>has indigenous name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">associates a local regional or cultural name with an individual concept</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
-        <rdfs:range rdf:resource="&xsd;string"/>
+		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <dct:source rdf:datatype="&xsd;string">Section 3.4, ISO 639-3</dct:source>
         <rdfs:isDefinedBy rdf:resource="&lcc-lr;"/>
 	</owl:DatatypeProperty>
@@ -449,25 +448,25 @@ This ontology (Language Representation) defines the model for the standard, base
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-lr;hasEnglishName"/>
-                <owl:someValuesFrom rdf:resource="&xsd;string"/>
+                <owl:someValuesFrom rdf:resource="&rdfs;Literal"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-lr;hasFrenchName"/>
-                <owl:someValuesFrom rdf:resource="&xsd;string"/>
+                <owl:someValuesFrom rdf:resource="&rdfs;Literal"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-lr;hasGermanName"/>
-                <owl:allValuesFrom rdf:resource="&xsd;string"/>
+                <owl:allValuesFrom rdf:resource="&rdfs;Literal"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-lr;hasIndigenousName"/>
-                <owl:allValuesFrom rdf:resource="&xsd;string"/>
+                <owl:allValuesFrom rdf:resource="&rdfs;Literal"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <skos:definition rdf:datatype="&xsd;string">a systematic use of sounds, characters, symbols or signs to communicate meaning</skos:definition>

--- a/Languages/LanguageRepresentation.rdf
+++ b/Languages/LanguageRepresentation.rdf
@@ -83,7 +83,7 @@ This ontology (Language Representation) defines the model for the standard, base
 6.  The LCC 1.0 version of this ontology, published in advance of the 2017 New Orleans OMG Technical Meeting, was current as of 31 July 2017 with respect to the ISO 639-1 and 639-2 codes included herein.</skos:historyNote>
 
         <skos:changeNote rdf:datatype="&xsd;string">The http://www.omg.org/spec/LCC/20151101/Languages/LanguageRepresentation.rdf version of this ontology was revised to reflect the issues addressed by the LCC 1.0 FTF report.</skos:changeNote>
-		<skos:changeNote rdf:datatype="&xsd;string">The http://www.omg.org/spec/LCC/20171801/Languages/LanguageRepresentation.rdf version of this ontology was revised loosen the range constraints on the hasName properties to enable use of language tags, as stated in the LCC 1.1 RTF report.</skos:changeNote>
+		<skos:changeNote rdf:datatype="&xsd;string">The http://www.omg.org/spec/LCC/20171801/Languages/LanguageRepresentation.rdf version of this ontology was revised to loosen the range constraints on the hasName properties to enable use of language tags, as stated in the LCC 1.1 RTF report.</skos:changeNote>
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 

--- a/Languages/LanguageRepresentation.rdf
+++ b/Languages/LanguageRepresentation.rdf
@@ -170,7 +170,6 @@ This ontology (Language Representation) defines the model for the standard, base
     <owl:DatatypeProperty rdf:about="&lcc-lr;hasName">
         <rdfs:label>has name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">associates a name, reference name, or appellation with an individual concept</skos:definition>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <dct:source rdf:datatype="&xsd;string">Section 3.4, ISO 639-3</dct:source>
         <rdfs:isDefinedBy rdf:resource="&lcc-lr;"/>
 	</owl:DatatypeProperty>
@@ -179,7 +178,6 @@ This ontology (Language Representation) defines the model for the standard, base
         <rdfs:label>has English name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">associates a name in English with an individual concept</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <dct:source rdf:datatype="&xsd;string">Section 3.4, ISO 639-3</dct:source>
         <rdfs:isDefinedBy rdf:resource="&lcc-lr;"/>
 	</owl:DatatypeProperty>
@@ -188,7 +186,6 @@ This ontology (Language Representation) defines the model for the standard, base
         <rdfs:label>has French name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">associates a name in French with an individual concept</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <dct:source rdf:datatype="&xsd;string">Section 3.4, ISO 639-3</dct:source>
         <rdfs:isDefinedBy rdf:resource="&lcc-lr;"/>
 	</owl:DatatypeProperty>
@@ -197,7 +194,6 @@ This ontology (Language Representation) defines the model for the standard, base
         <rdfs:label>has German name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">associates a name in German with an individual concept</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <rdfs:isDefinedBy rdf:resource="&lcc-lr;"/>
 	</owl:DatatypeProperty>
     
@@ -205,7 +201,6 @@ This ontology (Language Representation) defines the model for the standard, base
         <rdfs:label>has indigenous name</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">associates a local regional or cultural name with an individual concept</skos:definition>
         <rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
-		<rdfs:range rdf:resource="&rdfs;Literal"/>
         <dct:source rdf:datatype="&xsd;string">Section 3.4, ISO 639-3</dct:source>
         <rdfs:isDefinedBy rdf:resource="&lcc-lr;"/>
 	</owl:DatatypeProperty>
@@ -460,13 +455,13 @@ This ontology (Language Representation) defines the model for the standard, base
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-lr;hasGermanName"/>
-                <owl:allValuesFrom rdf:resource="&rdfs;Literal"/>
+                <owl:minCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&lcc-lr;hasIndigenousName"/>
-                <owl:allValuesFrom rdf:resource="&rdfs;Literal"/>
+                <owl:minCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <skos:definition rdf:datatype="&xsd;string">a systematic use of sounds, characters, symbols or signs to communicate meaning</skos:definition>


### PR DESCRIPTION
...to loosen restrictions on names from being xsd:string, to allow support for language tagged strings.
This is based on, and is an alternative, to the approach in PR #12 of explicitly using rdfs:Literal for range and restrictions. **So only one of these should be merged.**